### PR TITLE
Run query on eval-visualizer UI

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,3 +6,6 @@ VITE_ATTENTION_ENDPOINT=YOUR_ATTENTION_ENDPOINT
 
 # the endpoint of the bucket that stores eval results
 VITE_BUCKET_ENDPOINT=https://storage.googleapis.com/YOUR-BUCKET-NAME
+
+# The path to the directory where SQLite files are stored
+SQLITE_DB_PATH=/path/to/sqlite/files

--- a/.env.template
+++ b/.env.template
@@ -7,5 +7,5 @@ VITE_ATTENTION_ENDPOINT=YOUR_ATTENTION_ENDPOINT
 # the endpoint of the bucket that stores eval results
 VITE_BUCKET_ENDPOINT=https://storage.googleapis.com/YOUR-BUCKET-NAME
 
-# The path to the directory where SQLite files are stored
-SQLITE_DB_PATH=/path/to/sqlite/files
+# The path to the directory where SQLite files are stored i.e the path to the sqlite_dbs directory
+SQLITE_DB_PATH=../defog-data/sqlite_dbs

--- a/backend/main.py
+++ b/backend/main.py
@@ -58,8 +58,6 @@ async def run_query(request: RunQuery):
 def execute_query(query, db_type, db_name):
     # Create the base URL for the database type
     db_url = creds.get(db_type.value)
-    print("db_url here", db_url)
-
     if not db_url:
         return {"error": "Invalid database type"}
 
@@ -73,7 +71,6 @@ def execute_query(query, db_type, db_name):
 
         with engine.connect() as connection:
             result = connection.execute(text(query))
-            print("result here", result)
             rows = result.fetchall()
 
             # Convert rows into dictionaries if they are more than single values

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,7 +23,7 @@ app.add_middleware(
 )
 
 # Load the SQLite DB path from the environment
-SQLITE_DB_PATH = os.getenv("SQLITE_DB_PATH", "/default/path/to/sqlite/files")  # Default value if not in env
+SQLITE_DB_PATH = os.getenv("SQLITE_DB_PATH", "../defog-data/sqlite_dbs")  # Default value if not in env
 
 # Enum for Database Types
 class DBType(str, Enum):

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,79 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import SQLAlchemyError
+from pydantic import BaseModel
+from enum import Enum
+
+app = FastAPI()
+
+# Enable CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Enum for Database Types
+class DBType(str, Enum):
+    postgres = "postgres"
+    mysql = "mysql"
+    sqlite = "sqlite"
+    tsql = "tsql"
+
+# Database connection strings without a pre-defined database
+creds = {
+    "mysql": "mysql+mysqlconnector://root:password@localhost/derm_treatment",
+    "postgres": "postgresql+psycopg2://postgres:password@localhost/",
+    "sqlite": "sqlite:///your_sqlite_db.db"  # Local SQLite file
+}
+
+# Request Model for POST request
+class RunQuery(BaseModel):
+    db_name: str  # The database name we want to connect to
+    db_type: DBType  # The type of the database
+    query: str  # The actual SQL query to execute
+
+@app.get("/")
+def index():
+    return {"message": "Welcome to the FastAPI server"}
+
+# POST Endpoint to Run Query
+@app.post("/run_query")
+def run_query(request: RunQuery):
+    db_name = request.db_name
+    db_type = request.db_type
+    query = request.query
+    result = execute_query(query, db_type, db_name)
+    return {"result": result}
+
+def execute_query(query, db_type, db_name):
+    # Create the base URL for the database type
+    db_url = creds.get(db_type.value)
+    
+    if not db_url:
+        return {"error": "Invalid database type"}
+
+    try:
+        # For MySQL and Postgres, dynamically append the database name
+        # if db_type in {DBType.mysql, DBType.postgres}:
+        #     db_url = db_url + db_name
+        #     print(f"Connecting to database: {db_url}")
+
+        # Use SQLAlchemy to connect to the database
+        print(f"Connecting to database: {db_url}")
+        engine = create_engine(db_url)
+
+        with engine.connect() as connection:
+            print(f"Executing query: {query}")
+            result = connection.execute(text(query))  # Wrap query with `text()`
+            print(f"Query executed successfully")
+            
+            # Fetch all rows and return them as a list of dictionaries
+            rows = [dict(row) for row in result.fetchall()]
+            return rows
+    except SQLAlchemyError as e:
+        print(f"SQLAlchemy error: {str(e)}")  # Log the error
+        return {"error": str(e)}

--- a/backend/main.py
+++ b/backend/main.py
@@ -88,7 +88,7 @@ def execute_query(query, db_type, db_name):
                     else:
                         row_dict[col] = val
                 result_list.append(row_dict)
-
+            result.close()
             return result_list
     except SQLAlchemyError as e:
         return {"error": str(e)}

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from enum import Enum
 from decimal import Decimal
 import os
 from dotenv import load_dotenv
+import uvicorn
 
 # Load environment variables from .env file
 load_dotenv()
@@ -23,7 +24,10 @@ app.add_middleware(
 )
 
 # Load the SQLite DB path from the environment
-SQLITE_DB_PATH = os.getenv("SQLITE_DB_PATH", "../defog-data/sqlite_dbs")  # Default value if not in env
+SQLITE_DB_PATH = os.getenv(
+    "SQLITE_DB_PATH", "../defog-data/sqlite_dbs"
+)  # Default value if not in env
+
 
 # Enum for Database Types
 class DBType(str, Enum):
@@ -38,7 +42,7 @@ creds = {
     "mysql": "mysql+mysqlconnector://root:password@localhost/",
     "postgres": "postgresql+psycopg2://postgres:password@localhost/",
     "sqlite": "sqlite:///",
-    "tsql": "mssql+pyodbc://sa:password@localhost/{db_name}?driver=ODBC+Driver+17+for+SQL+Server"
+    "tsql": "mssql+pyodbc://sa:password@localhost/{db_name}?driver=ODBC+Driver+17+for+SQL+Server",
 }
 
 
@@ -104,3 +108,7 @@ def execute_query(query, db_type, db_name):
             return result_list
     except SQLAlchemyError as e:
         return {"error": str(e)}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "source .env && python get_fnames.py && vite --host 0.0.0.0",
+    "dev": "concurrently \"source .env && python get_fnames.py && vite --host 0.0.0.0\" \"uvicorn backend.main:app --reload\"",
     "build": "source .env && python get_fnames.py && vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
@@ -19,6 +19,7 @@
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.2.1",
+    "concurrently": "^7.6.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently \"source .env && python get_fnames.py && vite --host 0.0.0.0\" \"uvicorn backend.main:app --reload\"",
+    "dev": "source .env & python get_fnames.py & python main.py & vite --host 0.0.0.0",
     "build": "source .env && python get_fnames.py && vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/src/components/EvalVisualizerSingle.jsx
+++ b/src/components/EvalVisualizerSingle.jsx
@@ -232,6 +232,9 @@ const EvalVisualizerSingle = ({
                           setSiderVisible(false) :
                           setSiderVisible(true)
                         setSelectedItem(item);
+                        setGoldenQueryResult(null); // Reset previous golden results
+                        setGeneratedQueryResult(null); // Reset previous generated results
+                        setErrorMessage({"golden": null, "generated": null}); // Reset previous error messages
                       }}
                     >
                       &nbsp;
@@ -302,7 +305,8 @@ const EvalVisualizerSingle = ({
         </button>
 
         {/* Display results for Golden Query */}
-        <ResultsTable results={goldenQueryResult} />
+        {goldenQueryResult && <ResultsTable results={goldenQueryResult} />}
+
 
         {errorMessage.golden && (
           <div style={{ color: 'red' }}>
@@ -342,6 +346,7 @@ const EvalVisualizerSingle = ({
             </>
           }
           {selectedItem?.error_db_exec === 1 ? <p>Error Message: <pre>{selectedItem?.error_msg}</pre></p> : null}
+          {selectedItem?.error_db_exec !== 1 && 
           <div>
             {/* Button for running the Generated Query */}
             <button
@@ -359,9 +364,10 @@ const EvalVisualizerSingle = ({
               Run Generated Query
             </button>
           </div>
+          }
           
           {/* Display results for Generated Query */}
-          <ResultsTable results={generatedQueryResult} />
+          {generatedQueryResult && <ResultsTable results={generatedQueryResult} />}
 
           {/* Display error messages separately */}
           {errorMessage.generated && (

--- a/src/components/ResultsTable.jsx
+++ b/src/components/ResultsTable.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+const ResultsTable = ({ results }) => {
+  if (!results || results.length === 0) {
+    return <p>No results to display.</p>;
+  }
+
+  return (
+    <div
+      style={{
+        maxWidth: "100%",
+        maxHeight: "400px", 
+        overflowX: "auto",
+        overflowY: "auto",
+        margin: "10px 0", 
+        border: "1px solid #ddd",
+        borderRadius: "5px", 
+        padding: "5px", 
+        backgroundColor: "#f9f9f9",
+      }}
+    >
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "14px" }}> {/* Increased font size slightly */}
+        <thead>
+          <tr style={{ backgroundColor: "#f1f1f1", textAlign: "left" }}>
+            {Object.keys(results[0]).map((key) => (
+              <th
+                key={key}
+                style={{
+                  padding: "6px", // Increased padding slightly
+                  borderBottom: "1px solid #ddd",
+                  whiteSpace: "nowrap", // Prevent wrapping
+                }}
+              >
+                {key.replace("_", " ").toUpperCase()}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {results.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {Object.values(row).map((value, colIndex) => (
+                <td
+                  key={colIndex}
+                  style={{
+                    padding: "6px", // Increased padding slightly
+                    borderBottom: "1px solid #ddd",
+                    whiteSpace: "nowrap", // Prevent wrapping
+                  }}
+                >
+                  {value}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ResultsTable;


### PR DESCRIPTION
This has been tested for `mysql` and `sqlite` but not for `tsql` server yet which I will do using a docker image of `tsql`. 
 
Used `concurrently` to run both the python backend and frontend using just `npm run dev`.

Unlike other dbs, sqlite is stored as local files so thought it would be clean if we can define the path to the `sqlite_dbs` directory as an `env` variable. Defaulting this to `../defog-data/sqlite_dbs` do for the most part but sometimes our defog_data is elsewhere and that's when this will become helpful.

The UI is minimal for now but makes sure the overflow applies for too many rows and/or columns. Also made sure the results clear when the selection is changed.

<img width="635" alt="Screenshot 2024-09-23 at 8 00 09 PM" src="https://github.com/user-attachments/assets/c16329af-815c-400e-a563-e96e8ec452c5">

<img width="635" alt="Screenshot 2024-09-23 at 8 14 16 PM" src="https://github.com/user-attachments/assets/04e62da0-121e-45b4-bef1-aeb6e3467baf">


