### PR TITLE
Verification of dialect Golden Query to be correct

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,12 @@
+# Python Server Requirements
 fastapi
 starlette
 anyio
 sniffio
 uvicorn[standard]
 pydantic
+
+# Database connectors
 sqlalchemy
+mysql-connector-python
+psycopg2-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+starlette
+anyio
+sniffio
+uvicorn[standard]
+pydantic
+sqlalchemy

--- a/src/components/EvalVisualizerSingle.jsx
+++ b/src/components/EvalVisualizerSingle.jsx
@@ -85,7 +85,6 @@ const EvalVisualizerSingle = ({
   const getFiles = async () => {
     const response = await fetch(`/fnames.json`);
     const files = await response.json();
-    console.log(files);
     setAvailableFiles(files);
     setDataset(files[0]);
   }
@@ -102,10 +101,8 @@ const EvalVisualizerSingle = ({
     if (!selectedItem) {
       return;
     }
-    console.log('Running query on:', selectedItem);
   
     const queryToRun = queryType === "golden" ? selectedItem.query : selectedItem.generated_query;
-    console.log('Query to run:', queryToRun);
   
     try {
       const response = await fetch('http://localhost:8000/run_query', {
@@ -155,7 +152,7 @@ const EvalVisualizerSingle = ({
     } else if (datasetName.includes("v1")) {
       jsonFile = "api_v1_cot.json";
     } else if (datasetName.includes("basic")) {
-      jsonFile = "api_basic.json";
+      jsonFile = "api_basic_cot.json";
     } else {
       console.error("No matching JSON file found for the dataset.");
       setErrorMessage(prev => ({ ...prev, golden: 'No matching JSON file found for the dataset.' }));

--- a/src/components/EvalVisualizerSingle.jsx
+++ b/src/components/EvalVisualizerSingle.jsx
@@ -124,6 +124,7 @@ const EvalVisualizerSingle = ({
   
       if (queryType === "golden") {
         setGoldenQueryResult(result.result); // Store golden query result
+        setResultsSource(""); // Reset results source
         setErrorMessage(prev => ({ ...prev, golden: null })); // Clear golden query error
       } else {
         setGeneratedQueryResult(result.result); // Store generated query result
@@ -383,7 +384,7 @@ const EvalVisualizerSingle = ({
           </button>
         )}
         {/* Indicator that the results are from postgres golden query */}
-        {resultsSource === "postgresgolden" && <p>Results from Postgres Golden Query</p>}
+        {resultsSource === "postgresgolden" && <p>Results of the reference postgres Golden Query:</p>}
         {/* Display results for Golden Query */}
         {goldenQueryResult && <ResultsTable results={goldenQueryResult} />}
 


### PR DESCRIPTION
This [PR](https://linear.app/defog/issue/DEF-616/supplementary-helpful-feature-for-eval-visualizer-original-postgres) helps run the reference postgres golden query if we are not entirely sure about the dialect golden query being correct. This can easily catch incorrect dialect queries and help us be sure about the eval queries. For example, if I am seeing evals for a mysql run, can get an option to run the original postgres and see if my golden query results match with the reference postgres golden query results which is known to be correct. 

`We do not have indices in json files then how do we even find the corresponding postgres golden query? `
The question acts as an identifier because it is common across dialects. I know this is a workaround but seems to work. We use these three files to search the reference query, so these must in the public folder to make this work:
`public/api_advanced_cot.json`
`public/api_basic_cot.json`
`public/api_v1_cot.json`
<img width="1433" alt="Screenshot 2024-10-09 at 2 29 06 PM" src="https://github.com/user-attachments/assets/cc780813-adbf-4934-abc1-62ba782603b6">

<img width="1433" alt="Screenshot 2024-10-09 at 2 29 17 PM" src="https://github.com/user-attachments/assets/63aa4c67-26aa-4d5c-8237-48c6db3f9845">



An example of where this turns out helpful is the discrepancy below which signals that the mysql eval query is not correct:

<img width="675" alt="Screenshot 2024-10-09 at 2 24 26 PM" src="https://github.com/user-attachments/assets/55d21944-5079-423f-bd7d-bd81e5798fa9">
<img width="675" alt="Screenshot 2024-10-09 at 2 24 37 PM" src="https://github.com/user-attachments/assets/1e7f8616-e8a0-4793-bc17-64b92207c2d6">

